### PR TITLE
Add ECode APIs

### DIFF
--- a/src/StorageManager.js
+++ b/src/StorageManager.js
@@ -1,22 +1,9 @@
 export const FormatDirectory = (dir) => {
   return "C:" + dir.replaceAll("/", "\\");
 }
-
-export const GetFiles = (dir) => {
-  dir = FormatDirectory(dir);
-  const result = [];
-  Object.keys(localStorage).forEach(key => {
-    if (key.startsWith(`storage$${dir}\\`)) {
-      let itemFileName = key.substring(`storage$${dir}\\`.length);
-      if (itemFileName !== "") {
-        const itemFileMetadata = JSON.parse(localStorage.getItem(key));
-        if (itemFileMetadata.type === "folder") {
-          itemFileName = itemFileName.substring(0, itemFileName.length - 1);
-        }
-        result.push({ name: itemFileName, type: itemFileMetadata.type });
-      }
-    }
-  });
-
-  return result;
-};
+export const PrepareInternal = (dir) => {
+  if (dir.toUpperCase().startsWith("C:")) {
+    dir = dir.substring(2);
+  }
+  return dir.replaceAll("\\", "/");
+}

--- a/src/commands/cat.js
+++ b/src/commands/cat.js
@@ -1,4 +1,5 @@
 import path from "path-browserify";
+import {PrepareInternal} from "../StorageManager";
 
 export default class CatCommand {
   execute(term, params, directory, setDirectory) {
@@ -7,7 +8,7 @@ export default class CatCommand {
       term.writeln("No such file");
       return;
     }
-    param = param.replaceAll("\\", "/");
+    param = PrepareInternal(param);
 
     const dir = path.resolve(directory, param);
     if (!window.fs.existsSync(dir)) {
@@ -19,6 +20,6 @@ export default class CatCommand {
       return;
     }
 
-    term.writeln(window.fs.readSync(dir, 'utf8').replaceAll("\n", "\r\n"));
+    term.writeln(window.fs.readFileSync(dir, 'utf8').replaceAll("\n", "\r\n"));
   }
 }

--- a/src/commands/cd.js
+++ b/src/commands/cd.js
@@ -1,4 +1,5 @@
 import path from "path-browserify";
+import {PrepareInternal} from "../StorageManager";
 
 export default class ChangeDirectoryCommand {
   execute(term, params, directory, setDirectory) {
@@ -7,7 +8,7 @@ export default class ChangeDirectoryCommand {
       term.writeln("Invalid directory name");
       return;
     }
-    param = param.replaceAll("\\", "/");
+    param = PrepareInternal(param);
 
     const newCwd = path.resolve(directory, param);
     if (!window.fs.existsSync(newCwd)) {

--- a/src/commands/dir.js
+++ b/src/commands/dir.js
@@ -1,6 +1,7 @@
 import path from "path-browserify";
 import bytes from "bytes";
 import columnify from "columnify";
+import {PrepareInternal} from "../StorageManager";
 
 export default class DirectoryCommand {
   execute(term, params, directory, setDirectory) {
@@ -8,7 +9,16 @@ export default class DirectoryCommand {
     if (!param || param === "") {
       param = directory;
     } else {
-      param = param.replaceAll("\\", "/");
+      param = PrepareInternal(param);
+    }
+
+    if (!window.fs.existsSync(path.resolve(directory, param))) {
+      term.writeln("No such directory");
+      return;
+    }
+    if (!window.fs.statSync(path.resolve(directory, param)).isDirectory()) {
+      term.writeln("No such directory");
+      return;
     }
 
     const entries = window.fs.readdirSync(path.resolve(directory, param)).sort();

--- a/src/commands/ecode.js
+++ b/src/commands/ecode.js
@@ -1,0 +1,95 @@
+export default class ECodeAPICommand {
+    async execute(term, params, directory, setDirectory) {
+        const cmd = params[1];
+        switch (cmd) {
+            default:
+                term.writeln("");
+                term.writeln("  Usage:");
+                term.writeln("    ecode auth [token]          Login into ecode using API key");
+                term.writeln("    ecode account               Your account info");
+                term.writeln("    ecode logout                Remove credentials from account");
+                break
+            case 'auth':
+                const token = params[2];
+                if (!token || token === "") {
+                    term.writeln("Usage: ecode auth [token]")
+                    return;
+                }
+
+                this.login(term, token);
+                break
+            case 'account':
+                await this.fetchAccount(term);
+                break
+            case 'logout':
+                this.logout()
+                term.writeln("Signed out");
+                break
+        }
+    }
+
+    login(term, token) {
+        if (!window.fs.existsSync("/.config")) {
+            window.fs.mkdirSync("/.config");
+        }
+        if (!window.fs.statSync("/.config").isDirectory()) {
+            term.writeln("  \x1b[31;1m!!! WARNING !!!\x1b[0m");
+            term.writeln("  C:\\.config IS NOT A DIRECTORY!");
+            term.writeln("  CAN'T CREATE CONFIGURATION FILE!");
+            return;
+        }
+
+        if (window.fs.existsSync("/.config/ecode.token")) {
+            if (window.fs.statSync("/.config/ecode.token").isDirectory()) {
+                term.writeln("  \x1b[31;1m!!! WARNING !!!\x1b[0m");
+                term.writeln("  C:\\.config\\ecode.token IS A DIRECTORY!");
+                term.writeln("  CAN'T CREATE CONFIGURATION FILE!");
+                return;
+            }
+
+            term.writeln("  \x1b[31;1mYou are already logged in!\x1b[0m");
+            term.writeln("  Please log out first using 'ecode logout'");
+            return;
+        }
+
+        window.fs.writeFileSync("/.config/ecode.token", token);
+
+        term.writeln(`Signed in with token ${token}`);
+    }
+    logout() {
+        if (!window.fs.existsSync("/.config")) {
+            return;
+        }
+
+        if (!window.fs.existsSync("/.config/ecode.token")) {
+            return;
+        }
+
+        window.fs.unlinkSync("/.config/ecode.token");
+    }
+    async fetchAccount(term) {
+        if (!window.fs.existsSync("/.config/ecode.token")) {
+            term.writeln("  \x1b[33;1mNo API key found\x1b[0m");
+            term.writeln("  Please sign in first: ecode auth [token]");
+            return;
+        }
+
+        const token = window.fs.readFileSync("/.config/ecode.token", "utf8");
+        const d = await fetch(`https://api2.edwardcode.ru/method/auth/get_user?access_token=${token}`)
+          .then(d => d.json());
+
+        if (d.user_id) {
+            term.writeln("");
+            term.writeln("  You signed in into ECode APIs using account:");
+            term.writeln(`    Account ID: ${d.user_id}`);
+        } else {
+            term.writeln("");
+            term.writeln("  \x1b[33;1mFailed to get user information.\x1b[0m");
+            term.writeln("  You can log out and try to sign in again.");
+            term.writeln("  ");
+            term.writeln("  Possible reasons for this error are:");
+            term.writeln("  - Invalid API key");
+            term.writeln("  - You reached your API requests daily limit");
+        }
+    }
+  }

--- a/src/registration.js
+++ b/src/registration.js
@@ -16,35 +16,39 @@ import HttpcatCommand from "./commands/httpcat";
 import HttpdogCommand from "./commands/httpdog";
 import MakeDirectoryCommand from "./commands/mkdir";
 import CatCommand from "./commands/cat";
+import ECodeAPICommand from "./commands/ecode";
 
 export const registerAllCommands = () => {
   let registeredCommands = {};
 
-    // System commands
-    registeredCommands['ver'] = new VersionCommand();
-    registeredCommands['cls'] = new ClearCommand();
-    registeredCommands['wait'] = new WaitCommand();
-  
-    // File system commands
-    registeredCommands['dir'] = new DirectoryCommand();
-    registeredCommands['cd'] = new ChangeDirectoryCommand();
-    registeredCommands['mkdir'] = new MakeDirectoryCommand();
-    registeredCommands['type'] = new CatCommand();
+  // System commands
+  registeredCommands['ver'] = new VersionCommand();
+  registeredCommands['cls'] = new ClearCommand();
+  registeredCommands['wait'] = new WaitCommand();
 
-    // General commands
-    registeredCommands['credits'] = new CreditsCommand();
-    registeredCommands['github'] = new GithubCommand();
-    registeredCommands['date'] = new DateCommand();
-    registeredCommands['time'] = new TimeCommand();
-    registeredCommands['www'] = new WwwCommand();
-    registeredCommands['confetti'] = new ConfettiCommand();
-    registeredCommands['httpcat'] = new HttpcatCommand();
-    registeredCommands['httpdog'] = new HttpdogCommand();
-  
-    // Utility commands
-    registeredCommands['echo'] = new EchoCommand();
-    registeredCommands['ip'] = new IpCommand();
-    registeredCommands['geoip'] = new GeoIpCommand();
+  // File system commands
+  registeredCommands['dir'] = new DirectoryCommand();
+  registeredCommands['cd'] = new ChangeDirectoryCommand();
+  registeredCommands['mkdir'] = new MakeDirectoryCommand();
+  registeredCommands['type'] = new CatCommand();
+
+  // General commands
+  registeredCommands['credits'] = new CreditsCommand();
+  registeredCommands['github'] = new GithubCommand();
+  registeredCommands['date'] = new DateCommand();
+  registeredCommands['time'] = new TimeCommand();
+  registeredCommands['www'] = new WwwCommand();
+  registeredCommands['confetti'] = new ConfettiCommand();
+  registeredCommands['httpcat'] = new HttpcatCommand();
+  registeredCommands['httpdog'] = new HttpdogCommand();
+
+  // Utility commands
+  registeredCommands['echo'] = new EchoCommand();
+  registeredCommands['ip'] = new IpCommand();
+  registeredCommands['geoip'] = new GeoIpCommand();
+
+  // ECodeAPI
+  registeredCommands['ecode'] = new ECodeAPICommand();
 
   return registeredCommands;
 };


### PR DESCRIPTION
Команды для работы ECode API:

* `ecode auth [token]` - авторизация в ECode APIs. Не проверяет валидность токена
* `ecode account` - проверка авторизации. В случае успеха пишет Account ID
* `ecode logout` - выход из аккаунта.

Токен хранится в /.config/ecode.token (C:\.config\ecode.token)
Получить для использования у себя можно так:

```javascript
if (!window.fs.existsSync("/.config/ecode.token")) {
    term.writeln("  \x1b[33;1mNo API key found\x1b[0m");
    term.writeln("  Please sign in first: ecode auth [token]");
    return;
}

const token = window.fs.readFileSync("/.config/ecode.token", "utf8");
```